### PR TITLE
:fire: Filter out .mp3 suffix

### DIFF
--- a/rusty-songs/src/tui/ui/playlist.rs
+++ b/rusty-songs/src/tui/ui/playlist.rs
@@ -93,7 +93,12 @@ impl Playlist {
             .map(|song| {
                 let duration = format_duration(song.duration);
                 let spans = Spans::from(vec![
-                    Span::raw(song.title.clone()),
+                    Span::raw(
+                        song.title
+                            .strip_suffix(".mp3")
+                            .unwrap_or(&song.title)
+                            .to_string(),
+                    ),
                     Span::raw(format!(" ({})", duration)),
                 ]);
                 ListItem::new(spans)


### PR DESCRIPTION
This is a repetitive occurance thus it is rendered useless to have this suffix.

Has been tested :test_tube: 

closes #8 